### PR TITLE
Always initialize StartingValues

### DIFF
--- a/src/rgenoud.cpp
+++ b/src/rgenoud.cpp
@@ -137,7 +137,7 @@ extern "C"
     }
 
     // starting values
-    double **StartingValues;
+    double **StartingValues = nullptr;
     int nStartingValues;
     nStartingValues = asInteger(n_starting_values);
     if (nStartingValues > 0) {


### PR DESCRIPTION
This is flagged by `-Wsometimes-uninitialized`.

Below, `MainStructure->StartingValues=StartingValues` will be assigning an uninitialized value if the input ever receives `nStartingValues==0`.

If that's impossible, we should drop the `if (nStartingValues > 0)` branch.